### PR TITLE
Add Environment as optional parameter

### DIFF
--- a/Cronitor.Tests/TelemetryClientTests.cs
+++ b/Cronitor.Tests/TelemetryClientTests.cs
@@ -16,7 +16,9 @@ namespace Cronitor.Tests
             _httpClient = new Mock<HttpClient>();
             _client = new TelemetryClient(ApiKey, _httpClient.Object);
         }
-        
+
+        #region Run & RunAsync
+
         [Fact]
         public void ShouldExecuteRunMethod()
         {
@@ -106,6 +108,114 @@ namespace Cronitor.Tests
                 c.Message == $"'{message}'")), Times.Once);
             _httpClient.VerifyNoOtherCalls();
         }
+
+        [Fact]
+        public void ShouldExecuteRunMethodWithEnvironment()
+        {
+            var environment = "Production";
+
+            var command = new RunCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Run(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<RunCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Environment == environment &&
+                c.Endpoint == "run")), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteRunAsyncMethodWithEnvironment()
+        {
+            var environment = "Production";
+
+            var command = new RunCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.RunAsync(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<RunCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Environment == environment &&
+                c.Endpoint == "run")), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldExecuteRunMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+
+            var command = new RunCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Run(MonitorKey, message,environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<RunCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "run" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteRunAsyncMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+
+            var command = new RunCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.RunAsync(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<RunCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "run" &&
+                c.Message == $"'{message}'"&&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        #endregion
 
         [Fact]
         public void ShouldExecuteCompleteMethod()

--- a/Cronitor.Tests/TelemetryClientTests.cs
+++ b/Cronitor.Tests/TelemetryClientTests.cs
@@ -175,7 +175,7 @@ namespace Cronitor.Tests
             _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
 
             // Run
-            _client.Run(MonitorKey, message,environment);
+            _client.Run(MonitorKey, message, environment);
 
             // Verify
             _httpClient.Verify(x => x.SendAsync(It.Is<RunCommand>(c =>
@@ -210,12 +210,14 @@ namespace Cronitor.Tests
                 c.ApiKey == ApiKey &&
                 c.MonitorKey == MonitorKey &&
                 c.Endpoint == "run" &&
-                c.Message == $"'{message}'"&&
+                c.Message == $"'{message}'" &&
                 c.Environment == environment)), Times.Once);
             _httpClient.VerifyNoOtherCalls();
         }
 
         #endregion
+
+        #region Complete & CompleteAsync
 
         [Fact]
         public void ShouldExecuteCompleteMethod()
@@ -308,6 +310,112 @@ namespace Cronitor.Tests
         }
 
         [Fact]
+        public void ShouldExecuteCompleteMethodWithEnvironment()
+        {
+            var environment = "Production";
+            var command = new CompleteCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Complete(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<CompleteCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "complete" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteCompleteAsyncMethodWithException()
+        {
+            var environment = "Production";
+            var command = new CompleteCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.CompleteAsync(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<CompleteCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "complete" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldExecuteCompleteMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new CompleteCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Complete(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<CompleteCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "complete" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteCompleteAsyncMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new CompleteCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.CompleteAsync(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<CompleteCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "complete" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        #endregion
+
+        #region Fail & FailAsync
+
+        [Fact]
         public void ShouldExecuteFailMethod()
         {
             var command = new FailCommand()
@@ -396,6 +504,110 @@ namespace Cronitor.Tests
                 c.Message == $"'{message}'")), Times.Once);
             _httpClient.VerifyNoOtherCalls();
         }
+
+                [Fact]
+        public void ShouldExecuteFailMethodWithEnvironment()
+        {
+            var environment = "Production";
+            var command = new FailCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Fail(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<FailCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "fail" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteFailAsyncMethodWithEnvironment()
+        {
+            var environment = "Production";
+            var command = new FailCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.FailAsync(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<FailCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "fail" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldExecuteFailMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new FailCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Fail(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<FailCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "fail" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteFailAsyncMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new FailCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.FailAsync(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<FailCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "fail" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        #endregion
 
         [Fact]
         public void ShouldExecuteTickMethod()

--- a/Cronitor.Tests/TelemetryClientTests.cs
+++ b/Cronitor.Tests/TelemetryClientTests.cs
@@ -505,7 +505,7 @@ namespace Cronitor.Tests
             _httpClient.VerifyNoOtherCalls();
         }
 
-                [Fact]
+        [Fact]
         public void ShouldExecuteFailMethodWithEnvironment()
         {
             var environment = "Production";
@@ -609,6 +609,8 @@ namespace Cronitor.Tests
 
         #endregion
 
+        #region Tick & TickAsync
+
         [Fact]
         public void ShouldExecuteTickMethod()
         {
@@ -698,5 +700,109 @@ namespace Cronitor.Tests
                 c.Message == $"'{message}'")), Times.Once);
             _httpClient.VerifyNoOtherCalls();
         }
+
+        [Fact]
+        public void ShouldExecuteTickMethodWithEnvironment()
+        {
+            var environment = "Production";
+            var command = new TickCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Tick(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<TickCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "tick" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteTickAsyncMethodWithEnvironment()
+        {
+            var environment = "Production";
+            var command = new TickCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.TickAsync(MonitorKey, environment: environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<TickCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "tick" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldExecuteTickMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new TickCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            _client.Tick(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<TickCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "tick" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldExecuteTickAsyncMethodWithMessageAndEnvironment()
+        {
+            var message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var environment = "Production";
+            var command = new TickCommand()
+                .WithApiKey(ApiKey)
+                .WithMonitorKey(MonitorKey)
+                .WithMessage(message)
+                .WithEnvironment(environment);
+
+            // Setup
+            _httpClient.Setup(x => x.SendAsync(command)).Returns(Task.CompletedTask);
+
+            // Run
+            await _client.TickAsync(MonitorKey, message, environment);
+
+            // Verify
+            _httpClient.Verify(x => x.SendAsync(It.Is<TickCommand>(c =>
+                c.ApiKey == ApiKey &&
+                c.MonitorKey == MonitorKey &&
+                c.Endpoint == "tick" &&
+                c.Message == $"'{message}'" &&
+                c.Environment == environment)), Times.Once);
+            _httpClient.VerifyNoOtherCalls();
+        }
+
+        #endregion
     }
 }

--- a/Cronitor/TelemetryClient.cs
+++ b/Cronitor/TelemetryClient.cs
@@ -51,64 +51,52 @@ namespace Cronitor
             await PingAsync(command);
         }
 
-        public void Complete(string monitorKey)
+        public void Complete(string monitorKey, string message = null, string environment = null)
         {
-            Task.Run(async () => await CompleteAsync(monitorKey))
+            Task.Run(async () => await CompleteAsync(monitorKey, message, environment))
                 .Wait();
         }
 
-        public async Task CompleteAsync(string monitorKey)
+        public async Task CompleteAsync(string monitorKey, string message = null, string environment = null)
         {
             var command = new CompleteCommand()
                 .WithApiKey(_apiKey)
                 .WithMonitorKey(monitorKey);
 
-            await PingAsync(command);
-        }
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                command.WithMessage(message);
+            }
 
-        public void Complete(string monitorKey, string message)
-        {
-            Task.Run(async () => await CompleteAsync(monitorKey, message))
-                .Wait();
-        }
-
-        public async Task CompleteAsync(string monitorKey, string message)
-        {
-            var command = new CompleteCommand()
-                .WithApiKey(_apiKey)
-                .WithMonitorKey(monitorKey)
-                .WithMessage(message);
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                command.WithEnvironment(environment);
+            }
 
             await PingAsync(command);
         }
 
-        public void Fail(string monitorKey)
+        public void Fail(string monitorKey, string message = null, string environment = null)
         {
-            Task.Run(async () => await FailAsync(monitorKey))
+            Task.Run(async () => await FailAsync(monitorKey, message, environment))
                 .Wait();
         }
 
-        public async Task FailAsync(string monitorKey)
+        public async Task FailAsync(string monitorKey, string message = null, string environment = null)
         {
             var command = new FailCommand()
                 .WithApiKey(_apiKey)
                 .WithMonitorKey(monitorKey);
 
-            await PingAsync(command);
-        }
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                command.WithMessage(message);
+            }
 
-        public void Fail(string monitorKey, string message)
-        {
-            Task.Run(async () => await FailAsync(monitorKey, message))
-                .Wait();
-        }
-
-        public async Task FailAsync(string monitorKey, string message)
-        {
-            var command = new FailCommand()
-                .WithApiKey(_apiKey)
-                .WithMonitorKey(monitorKey)
-                .WithMessage(message);
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                command.WithEnvironment(environment);
+            }
 
             await PingAsync(command);
         }

--- a/Cronitor/TelemetryClient.cs
+++ b/Cronitor/TelemetryClient.cs
@@ -101,37 +101,30 @@ namespace Cronitor
             await PingAsync(command);
         }
 
-        public void Tick(string monitorKey)
+        public void Tick(string monitorKey, string message = null, string environment = null)
         {
-            Task.Run(async () => await TickAsync(monitorKey))
+            Task.Run(async () => await TickAsync(monitorKey, message, environment))
                 .Wait();
         }
 
-        public async Task TickAsync(string monitorKey)
+        public async Task TickAsync(string monitorKey, string message = null, string environment = null)
         {
             var command = new TickCommand()
                 .WithApiKey(_apiKey)
                 .WithMonitorKey(monitorKey);
 
-            await PingAsync(command);
-        }
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                command.WithMessage(message);
+            }
 
-        public void Tick(string monitorKey, string message)
-        {
-            Task.Run(async () => await TickAsync(monitorKey, message))
-                .Wait();
-        }
-
-        public async Task TickAsync(string monitorKey, string message)
-        {
-            var command = new TickCommand()
-                .WithApiKey(_apiKey)
-                .WithMonitorKey(monitorKey)
-                .WithMessage(message);
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                command.WithEnvironment(environment);
+            }
 
             await PingAsync(command);
         }
-
 
         public void Ping(Command command)
         {

--- a/Cronitor/TelemetryClient.cs
+++ b/Cronitor/TelemetryClient.cs
@@ -26,33 +26,27 @@ namespace Cronitor
             _apiKey = apiKey;
         }
 
-        public void Run(string monitorKey)
+        public void Run(string monitorKey, string message = null, string environment = null)
         {
-            Task.Run(async () => await RunAsync(monitorKey))
+            Task.Run(async () => await RunAsync(monitorKey, message, environment))
                 .Wait();
         }
 
-        public async Task RunAsync(string monitorKey)
+        public async Task RunAsync(string monitorKey, string message = null, string environment = null)
         {
             var command = new RunCommand()
                 .WithApiKey(_apiKey)
                 .WithMonitorKey(monitorKey);
 
-            await PingAsync(command);
-        }
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                command.WithMessage(message);
+            }
 
-        public void Run(string monitorKey, string message)
-        {
-            Task.Run(async () => await RunAsync(monitorKey, message))
-                .Wait();
-        }
-
-        public async Task RunAsync(string monitorKey, string message)
-        {
-            var command = new RunCommand()
-                .WithApiKey(_apiKey)
-                .WithMonitorKey(monitorKey)
-                .WithMessage(message);
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                command.WithEnvironment(environment);
+            }
 
             await PingAsync(command);
         }


### PR DESCRIPTION
Right now, there are no easy-to-use methods available on the `TelemetryClient` to include an environment.
The underlying code-base does accommodate it (nice work BTW!). 

However, the user has to manually craft a command and use `Ping` or `PingAsync`.
This is not too bad but I thought I'd see if there was an appetite for more formal methods to supply the environment.

**Disclaimer:** I too am not the biggest fan of having to resort to optional named parameters, however with everything being `string` there is either this or having uniquely named methods e.g `RunWithEnvironment` 🤮

Usage would look something like:

```csharp

var monitoryKey = "MyCoolKey";
var environment = "Production";

var telemetryClient = new TelemetryClient("apikey");

await telemetryClient.RunAsync(monitoryKey, environment: environment)
# or 
await telemetryClient.RunAsync(monitoryKey, "my message", environment)
```